### PR TITLE
Stream media content only in case of HTTP GET method

### DIFF
--- a/media/livestream.php
+++ b/media/livestream.php
@@ -13,27 +13,30 @@ header('Last-Modified: '.gmdate("D, d M Y H:i:s", time())." GMT");
 header('Accept-Range: none');
 header('Content-Type: video/mpeg');
 
-$first = true;
-while (true) {
-  $seekpos = 0;
-  if ($first) {
-    $first = false;
-    $seekpos = (int)((microtime(true)*100)%1000);
-    $seekpos *= 7*188;
-  }
-  fseek($fp, $seekpos, SEEK_SET);
-  $start = time();
-  $bcount = 0;
-  while (!feof($fp) && !connection_aborted()) {
-    $b = @fread($fp, 7520);
-    $check = (int)(($start+($bcount/$byterate)-microtime(true))*10)-1;
-    if ($check>0) {
-      usleep($check*100);
+if ($_SERVER['REQUEST_METHOD'] == 'GET') {
+  $first = true;
+  while (true) {
+    $seekpos = 0;
+    if ($first) {
+      $first = false;
+      $seekpos = (int)((microtime(true)*100)%1000);
+      $seekpos *= 7*188;
     }
-    echo $b;
-    $bcount += strlen($b);
+    fseek($fp, $seekpos, SEEK_SET);
+    $start = time();
+    $bcount = 0;
+    while (!feof($fp) && !connection_aborted()) {
+      $b = @fread($fp, 7520);
+      $check = (int)(($start+($bcount/$byterate)-microtime(true))*10)-1;
+      if ($check>0) {
+        usleep($check*100);
+      }
+      echo $b;
+      $bcount += strlen($b);
+    }
   }
 }
+
 fclose($fp);
 
 ?>

--- a/media/mp3radio.php
+++ b/media/mp3radio.php
@@ -17,19 +17,20 @@ header('Content-Length: '.$size);
 header('Connection: close');
 
 # start streaming
-$fp = @fopen($vidfile,'rb');
-$start = time()-4;
-$bcount = 0;
-while (!feof($fp) && $bcount<$size && !connection_aborted()) {
-  $b = @fread($fp, min(8192, $size-$bcount));
-  $check = $start+((int)($bcount/$byterate))-time();
-  if ($check>0) {
-    flush();
-    sleep($check);
+if ($_SERVER['REQUEST_METHOD'] == 'GET') {
+  $fp = @fopen($vidfile,'rb');
+  $start = time()-4;
+  $bcount = 0;
+  while (!feof($fp) && $bcount<$size && !connection_aborted()) {
+    $b = @fread($fp, min(8192, $size-$bcount));
+    $check = $start+((int)($bcount/$byterate))-time();
+    if ($check>0) {
+      flush();
+      sleep($check);
+    }
+    echo $b;
+    $bcount += strlen($b);
   }
-  echo $b;
-  $bcount += strlen($b);
+  fclose($fp);
 }
-fclose($fp);
-
 ?>

--- a/media/stream.php
+++ b/media/stream.php
@@ -8,6 +8,8 @@ if(!$fp || !$size || !$byterate || !$contenttype) {
   echo "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n<html><head>\n<title>404 Not Found</title>\n</head><body>\n<h1>Not Found</h1>\n<p>The requested video was not found on this server.</p>\n</body></html>";
   exit;
 }
+
+
 $range = array();
 $range[0] = 0;
 $range[1] = $size-1;
@@ -36,18 +38,20 @@ header('Content-Length: '.$clength);
 header('Content-Range: bytes '.$range[0].'-'.$range[1].'/'.$size);
 header('Content-Type: '.$contenttype);
 
-# start streaming
-$start = time()-4;
-$bcount = 0;
-while (!feof($fp) && $bcount<$clength && !connection_aborted()) {
-  $b = @fread($fp, min(8192, $clength-$bcount));
-  $check = $start+((int)($bcount/$byterate))-time();
-  if ($check>0) {
-    flush();
-    sleep($check);
+if ($_SERVER['REQUEST_METHOD'] == 'GET') {
+  # start streaming
+  $start = time()-4;
+  $bcount = 0;
+  while (!feof($fp) && $bcount<$clength && !connection_aborted()) {
+    $b = @fread($fp, min(8192, $clength-$bcount));
+    $check = $start+((int)($bcount/$byterate))-time();
+    if ($check>0) {
+      flush();
+      sleep($check);
+    }
+    echo $b;
+    $bcount += strlen($b);
   }
-  echo $b;
-  $bcount += strlen($b);
 }
 fclose($fp);
 


### PR DESCRIPTION
This fixes requests that use HTTP HEAD method which takes very long time due to usleep calls in php code.

Test command:
`$ wget --method HEAD -S  http://itv.mit-xperts.com/hbbtvtest/media/mp3radio.php`
