### PR TITLE
fix typo: 'suppored' → 'supported'

### DIFF
--- a/accessab/index.php
+++ b/accessab/index.php
@@ -293,7 +293,7 @@ function suppressFeature(id) {
       if (result.value==="suppressing") {
         showStatus(true, "Feature "+id+" is now suppressed, response was "+result.value);
       } else {
-        showStatus(true, "Feature "+id+" is not suppored, response was "+result.value);
+        showStatus(true, "Feature "+id+" is not supported, response was "+result.value);
       }
     });
   });


### PR DESCRIPTION
There is a minor typo in the `suppressFeature` function located in `accessab/index.php`.

In the following line:

```javascript
showStatus(true, "Feature "+id+" is not suppored, response was "+result.value);
```
Should be:

```javascript
showStatus(true, "Feature "+id+" is not supported, response was "+result.value);
```